### PR TITLE
Correct SKILLTREE_BUTTON_CONTROLLS

### DIFF
--- a/Plugin/src/main/java/cz/neumimto/rpg/configuration/PluginConfig.java
+++ b/Plugin/src/main/java/cz/neumimto/rpg/configuration/PluginConfig.java
@@ -191,8 +191,8 @@ public class PluginConfig {
 	public static List<String> SKILLTREE_BUTTON_CONTROLLS = new ArrayList<String>() {{
 		add("North,minecraft:diamond_hoe,Up,1");
 		add("West,minecraft:diamond_hoe,Right,2");
-		add("East,minecraft:diamond_hoe,Down,3");
-		add("South,minecraft:diamond_hoe,Left,4");
+		add("East,minecraft:diamond_hoe,Left,3");
+		add("South,minecraft:diamond_hoe,Down,4");
 	}};
 
 	@ConfigValue


### PR DESCRIPTION
Corrected an issue where Left and Down in the skilltree menu were swapped around in the default config.

Fixed issue #40 